### PR TITLE
Add python3 support

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 tzselect dependencies:
     - pytz
-    - webhelpers (for webhelpers.html.tags.select)
+    - webhelpers (for webhelpers.html.tags.select) for python 2 / webhelpers2 for python3
 
 >>> from tzselect import tzselect
 >>> tzselect('timezones', 'US/Pacific')


### PR DESCRIPTION
Added python3 support.

webhelpers only works on python2, so webhelpers2 in the dependency needed for python3.